### PR TITLE
Compute getTopDeclSymbols for TypeSig constructor

### DIFF
--- a/src/Language/Haskell/Names/ModuleSymbols.hs
+++ b/src/Language/Haskell/Names/ModuleSymbols.hs
@@ -103,7 +103,29 @@ getTopDeclSymbols impTbl modulename d = (case d of
           GadtDecl _ cn (fromMaybe [] -> fields) _ty <- gadtDecls
           return (cn , [f | FieldDecl _ fNames _ <- fields, f <- fNames])
 
-    _ -> [])
+    TypeSig _ names _ -> map (Value (sModuleName modulename) . sName) names
+
+    ClosedTypeFamDecl {} -> []
+    TypeInsDecl {} -> []
+    InstDecl {} -> []
+    DerivDecl {} -> []
+    InfixDecl {} -> []
+    DefaultDecl {} -> []
+    SpliceDecl {} -> []
+    PatSynSig {} -> []
+    PatSyn {} -> []
+    ForExp {} -> []
+    RulePragmaDecl {} -> []
+    DeprPragmaDecl {} -> []
+    WarnPragmaDecl {} -> []
+    InlineSig {} -> []
+    InlineConlikeSig {} -> []
+    SpecSig {} -> []
+    SpecInlineSig {} -> []
+    InstSig {} -> []
+    AnnPragma {} -> []
+    MinimalPragma {} -> []
+    RoleAnnotDecl {} -> [])
         where
             declHeadSymbol c dh = c (sModuleName modulename) (sName (getDeclHeadName dh))
 


### PR DESCRIPTION
Is there a reason no symbols are returned by getTopDeclSymbols for a type signature?