### PR TITLE
Make haskell-names work with the "one-ast" branch of haskell-src-ext

### DIFF
--- a/src/Language/Haskell/Names/Environment.hs
+++ b/src/Language/Haskell/Names/Environment.hs
@@ -13,9 +13,8 @@ module Language.Haskell.Names.Environment
   ) where
 
 import Language.Haskell.Names.Types (Environment, Symbol(..))
-import Language.Haskell.Exts (ModuleName(ModuleName),prettyPrint,Name)
-import Language.Haskell.Names.SyntaxUtils (stringToName,nameToString,annName)
-import Language.Haskell.Exts.Annotated.Simplify (sName)
+import Language.Haskell.Exts (ModuleName(ModuleName),Name,prettyPrint)
+import Language.Haskell.Names.SyntaxUtils (stringToName,nameToString,dropAnn, annName)
 import qualified Data.ByteString.Lazy as BS (readFile, writeFile, pack)
 import Data.Aeson
 import Data.Monoid
@@ -49,7 +48,7 @@ data SymbolsFileException =
   deriving (Typeable, Show)
 instance Exception SymbolsFileException
 
-prettyName :: Name -> String
+prettyName :: Name () -> String
 prettyName = nameToString . annName
 
 instance ToJSON Symbol where
@@ -86,13 +85,13 @@ symbolEntity i = case i of
   DataFam {} -> "dataFamily"
   Class   {} -> "class"
 
-parseName :: String -> Name
-parseName = sName . stringToName
+parseName :: String -> Name ()
+parseName = dropAnn . stringToName
 
 instance FromJSON Symbol where
   parseJSON (Object v) = do
     entity <- v .: "entity"
-    symbolmodule <- ModuleName <$> v .: "module"
+    symbolmodule <- ModuleName () <$> v .: "module"
     symbolname <- parseName <$> v .: "name"
 
     case entity :: String of
@@ -133,5 +132,5 @@ loadBase = do
     return (moduleName, symbols))
   return (Map.fromList moduleSymbols)
 
-baseModules :: [ModuleName]
-baseModules = map ModuleName ["Control.Applicative","Control.Arrow","Control.Category","Control.Concurrent.Chan","Control.Concurrent.MVar","Control.Concurrent.QSem","Control.Concurrent.QSemN","Control.Concurrent","Control.Exception.Base","Control.Exception","Control.Monad.Fix","Control.Monad.Instances","Control.Monad.ST.Imp","Control.Monad.ST.Lazy.Imp","Control.Monad.ST.Lazy.Safe","Control.Monad.ST.Lazy.Unsafe","Control.Monad.ST.Lazy","Control.Monad.ST.Safe","Control.Monad.ST.Strict","Control.Monad.ST.Unsafe","Control.Monad.ST","Control.Monad.Zip","Control.Monad","Data.Bits","Data.Bool","Data.Char","Data.Complex","Data.Data","Data.Dynamic","Data.Either","Data.Eq","Data.Fixed","Data.Foldable","Data.Function","Data.Functor","Data.IORef","Data.Int","Data.Ix","Data.List","Data.Maybe","Data.Monoid","Data.OldTypeable.Internal","Data.OldTypeable","Data.Ord","Data.Ratio","Data.STRef.Lazy","Data.STRef.Strict","Data.STRef","Data.String","Data.Traversable","Data.Tuple","Data.Typeable.Internal","Data.Typeable","Data.Unique","Data.Version","Data.Word","Debug.Trace","Foreign.C.Error","Foreign.C.String","Foreign.C.Types","Foreign.C","Foreign.Concurrent","Foreign.ForeignPtr.Imp","Foreign.ForeignPtr.Safe","Foreign.ForeignPtr.Unsafe","Foreign.ForeignPtr","Foreign.Marshal.Alloc","Foreign.Marshal.Array","Foreign.Marshal.Error","Foreign.Marshal.Pool","Foreign.Marshal.Safe","Foreign.Marshal.Unsafe","Foreign.Marshal.Utils","Foreign.Marshal","Foreign.Ptr","Foreign.Safe","Foreign.StablePtr","Foreign.Storable","Foreign","GHC.Arr","GHC.Base","GHC.Char","GHC.Conc.IO","GHC.Conc.Signal","GHC.Conc.Sync","GHC.Conc","GHC.ConsoleHandler","GHC.Constants","GHC.Desugar","GHC.Enum","GHC.Environment","GHC.Err","GHC.Event.Array","GHC.Event.Clock","GHC.Event.Control","GHC.Event.EPoll","GHC.Event.IntMap","GHC.Event.Internal","GHC.Event.KQueue","GHC.Event.Manager","GHC.Event.PSQ","GHC.Event.Poll","GHC.Event.Thread","GHC.Event.TimerManager","GHC.Event.Unique","GHC.Event","GHC.Exception","GHC.Exts","GHC.Fingerprint.Type","GHC.Fingerprint","GHC.Float.ConversionUtils","GHC.Float.RealFracMethods","GHC.Float","GHC.Foreign","GHC.ForeignPtr","GHC.GHCi","GHC.Generics","GHC.IO.Buffer","GHC.IO.BufferedIO","GHC.IO.Device","GHC.IO.Encoding.CodePage","GHC.IO.Encoding.Failure","GHC.IO.Encoding.Iconv","GHC.IO.Encoding.Latin1","GHC.IO.Encoding.Types","GHC.IO.Encoding.UTF16","GHC.IO.Encoding.UTF32","GHC.IO.Encoding.UTF8","GHC.IO.Encoding","GHC.IO.Exception","GHC.IO.FD","GHC.IO.Handle.FD","GHC.IO.Handle.Internals","GHC.IO.Handle.Text","GHC.IO.Handle.Types","GHC.IO.Handle","GHC.IO.IOMode","GHC.IO","GHC.IOArray","GHC.IORef","GHC.IP","GHC.Int","GHC.List","GHC.MVar","GHC.Num","GHC.PArr","GHC.Pack","GHC.Profiling","GHC.Ptr","GHC.Read","GHC.Real","GHC.ST","GHC.STRef","GHC.Show","GHC.Stable","GHC.Stack","GHC.Stats","GHC.Storable","GHC.TopHandler","GHC.TypeLits","GHC.Unicode","GHC.Weak","GHC.Word","Numeric","Prelude","System.CPUTime","System.Console.GetOpt","System.Environment.ExecutablePath","System.Environment","System.Exit","System.IO.Error","System.IO.Unsafe","System.IO","System.Info","System.Mem.StableName","System.Mem.Weak","System.Mem","System.Posix.Internals","System.Posix.Types","System.Timeout","Text.ParserCombinators.ReadP","Text.ParserCombinators.ReadPrec","Text.Printf","Text.Read.Lex","Text.Read","Text.Show.Functions","Text.Show","Unsafe.Coerce","GHC.CString","GHC.Classes","GHC.Debug","GHC.IntWord64","GHC.Magic","GHC.Prim","GHC.PrimopWrappers","GHC.Tuple","GHC.Types","GHC.Integer.Logarithms.Internals","GHC.Integer.Logarithms","GHC.Integer.Simple.Internals","GHC.Integer.Type","GHC.Integer"]
+baseModules :: [ModuleName ()]
+baseModules = map (ModuleName ()) ["Control.Applicative","Control.Arrow","Control.Category","Control.Concurrent.Chan","Control.Concurrent.MVar","Control.Concurrent.QSem","Control.Concurrent.QSemN","Control.Concurrent","Control.Exception.Base","Control.Exception","Control.Monad.Fix","Control.Monad.Instances","Control.Monad.ST.Imp","Control.Monad.ST.Lazy.Imp","Control.Monad.ST.Lazy.Safe","Control.Monad.ST.Lazy.Unsafe","Control.Monad.ST.Lazy","Control.Monad.ST.Safe","Control.Monad.ST.Strict","Control.Monad.ST.Unsafe","Control.Monad.ST","Control.Monad.Zip","Control.Monad","Data.Bits","Data.Bool","Data.Char","Data.Complex","Data.Data","Data.Dynamic","Data.Either","Data.Eq","Data.Fixed","Data.Foldable","Data.Function","Data.Functor","Data.IORef","Data.Int","Data.Ix","Data.List","Data.Maybe","Data.Monoid","Data.OldTypeable.Internal","Data.OldTypeable","Data.Ord","Data.Ratio","Data.STRef.Lazy","Data.STRef.Strict","Data.STRef","Data.String","Data.Traversable","Data.Tuple","Data.Typeable.Internal","Data.Typeable","Data.Unique","Data.Version","Data.Word","Debug.Trace","Foreign.C.Error","Foreign.C.String","Foreign.C.Types","Foreign.C","Foreign.Concurrent","Foreign.ForeignPtr.Imp","Foreign.ForeignPtr.Safe","Foreign.ForeignPtr.Unsafe","Foreign.ForeignPtr","Foreign.Marshal.Alloc","Foreign.Marshal.Array","Foreign.Marshal.Error","Foreign.Marshal.Pool","Foreign.Marshal.Safe","Foreign.Marshal.Unsafe","Foreign.Marshal.Utils","Foreign.Marshal","Foreign.Ptr","Foreign.Safe","Foreign.StablePtr","Foreign.Storable","Foreign","GHC.Arr","GHC.Base","GHC.Char","GHC.Conc.IO","GHC.Conc.Signal","GHC.Conc.Sync","GHC.Conc","GHC.ConsoleHandler","GHC.Constants","GHC.Desugar","GHC.Enum","GHC.Environment","GHC.Err","GHC.Event.Array","GHC.Event.Clock","GHC.Event.Control","GHC.Event.EPoll","GHC.Event.IntMap","GHC.Event.Internal","GHC.Event.KQueue","GHC.Event.Manager","GHC.Event.PSQ","GHC.Event.Poll","GHC.Event.Thread","GHC.Event.TimerManager","GHC.Event.Unique","GHC.Event","GHC.Exception","GHC.Exts","GHC.Fingerprint.Type","GHC.Fingerprint","GHC.Float.ConversionUtils","GHC.Float.RealFracMethods","GHC.Float","GHC.Foreign","GHC.ForeignPtr","GHC.GHCi","GHC.Generics","GHC.IO.Buffer","GHC.IO.BufferedIO","GHC.IO.Device","GHC.IO.Encoding.CodePage","GHC.IO.Encoding.Failure","GHC.IO.Encoding.Iconv","GHC.IO.Encoding.Latin1","GHC.IO.Encoding.Types","GHC.IO.Encoding.UTF16","GHC.IO.Encoding.UTF32","GHC.IO.Encoding.UTF8","GHC.IO.Encoding","GHC.IO.Exception","GHC.IO.FD","GHC.IO.Handle.FD","GHC.IO.Handle.Internals","GHC.IO.Handle.Text","GHC.IO.Handle.Types","GHC.IO.Handle","GHC.IO.IOMode","GHC.IO","GHC.IOArray","GHC.IORef","GHC.IP","GHC.Int","GHC.List","GHC.MVar","GHC.Num","GHC.PArr","GHC.Pack","GHC.Profiling","GHC.Ptr","GHC.Read","GHC.Real","GHC.ST","GHC.STRef","GHC.Show","GHC.Stable","GHC.Stack","GHC.Stats","GHC.Storable","GHC.TopHandler","GHC.TypeLits","GHC.Unicode","GHC.Weak","GHC.Word","Numeric","Prelude","System.CPUTime","System.Console.GetOpt","System.Environment.ExecutablePath","System.Environment","System.Exit","System.IO.Error","System.IO.Unsafe","System.IO","System.Info","System.Mem.StableName","System.Mem.Weak","System.Mem","System.Posix.Internals","System.Posix.Types","System.Timeout","Text.ParserCombinators.ReadP","Text.ParserCombinators.ReadPrec","Text.Printf","Text.Read.Lex","Text.Read","Text.Show.Functions","Text.Show","Unsafe.Coerce","GHC.CString","GHC.Classes","GHC.Debug","GHC.IntWord64","GHC.Magic","GHC.Prim","GHC.PrimopWrappers","GHC.Tuple","GHC.Types","GHC.Integer.Logarithms.Internals","GHC.Integer.Logarithms","GHC.Integer.Simple.Internals","GHC.Integer.Type","GHC.Integer"]

--- a/src/Language/Haskell/Names/GetBound.hs
+++ b/src/Language/Haskell/Names/GetBound.hs
@@ -8,8 +8,7 @@ module Language.Haskell.Names.GetBound
 import Data.Generics.Uniplate.Data
 import Data.Data
 
-import qualified Language.Haskell.Exts as UnAnn
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 import Language.Haskell.Names.RecordWildcards
 import Language.Haskell.Names.SyntaxUtils
 import qualified Language.Haskell.Names.GlobalSymbolTable as Global
@@ -144,7 +143,7 @@ instance (Data l) => GetBound (Pat l) l where
       dropExp (PViewPat _ _ x) = x
       dropExp x = x
 
-      getRecVars :: [UnAnn.Name] -> PatField l -> [Name l]
+      getRecVars :: [Name ()] -> PatField l -> [Name l]
       getRecVars _ PFieldPat {} = [] -- this is already found by the generic algorithm
       getRecVars _ (PFieldPun _ qn) = [qNameToName qn]
       getRecVars elidedFields (PFieldWildcard l) = map (setAnn l . annName) elidedFields

--- a/src/Language/Haskell/Names/GlobalSymbolTable.hs
+++ b/src/Language/Haskell/Names/GlobalSymbolTable.hs
@@ -2,12 +2,7 @@
 -- | This module is designed to be imported qualified.
 module Language.Haskell.Names.GlobalSymbolTable where
 
-import Language.Haskell.Exts (
-    QName)
-import qualified Language.Haskell.Exts.Annotated as Ann (
-    QName)
-import Language.Haskell.Exts.Annotated.Simplify (
-    sQName)
+import Language.Haskell.Exts hiding (NewType)
 
 import Data.Map (
     Map)
@@ -18,9 +13,10 @@ import Control.Arrow
 import Data.List as List (union)
 
 import Language.Haskell.Names.Types
+import Language.Haskell.Names.SyntaxUtils (dropAnn)
 
 -- | Global symbol table — contains names declared somewhere at the top level.
-type Table = Map QName [Symbol]
+type Table = Map (QName ()) [Symbol]
 
 -- | Empty global symbol table.
 empty :: Table
@@ -35,17 +31,17 @@ data Result l
   | Error (Error l)
   | Special
 
-lookupValue :: Ann.QName l -> Table -> Result l
+lookupValue :: QName l -> Table -> Result l
 lookupValue qn = lookupName qn . filterTable isValue
 
-lookupType :: Ann.QName l -> Table -> Result l
+lookupType :: QName l -> Table -> Result l
 lookupType qn = lookupName qn . filterTable isType
 
-lookupMethodOrAssociate :: Ann.QName l -> Table -> Result l
+lookupMethodOrAssociate :: QName l -> Table -> Result l
 lookupMethodOrAssociate qn = lookupName qn . filterTable isMethodOrAssociated
 
-lookupName :: Ann.QName l -> Table -> Result l
-lookupName qn table = case Map.lookup (sQName qn) table of
+lookupName :: QName l -> Table -> Result l
+lookupName qn table = case Map.lookup (dropAnn qn) table of
     Nothing -> Error $ ENotInScope qn
     Just [] -> Error $ ENotInScope qn
     Just [i] -> SymbolFound i
@@ -79,6 +75,6 @@ isMethodOrAssociated symbol = case symbol of
     DataFam {} -> True
     _ -> False
 
-fromList :: [(QName,Symbol)] -> Table
+fromList :: [(QName (),Symbol)] -> Table
 fromList = Map.fromListWith List.union . map (second (:[]))
 

--- a/src/Language/Haskell/Names/Imports.hs
+++ b/src/Language/Haskell/Names/Imports.hs
@@ -13,11 +13,9 @@ import Control.Applicative
 
 import Control.Monad.Writer
 import Data.Map as Map (lookup)
-import qualified Language.Haskell.Exts as UnAnn (
+import Language.Haskell.Exts (
   ModuleName(ModuleName))
-import Language.Haskell.Exts.Annotated.Simplify (
-  sName,sModuleName)
-import Language.Haskell.Exts.Annotated (
+import Language.Haskell.Exts (
   Module(Module), ModuleName,ImportDecl(..),
   ann,ImportSpecList(..),ImportSpec(..),Name(..),
   Annotated)
@@ -46,26 +44,26 @@ importTable environment modul =
       DisableExtension ImplicitPrelude `elem` extensions || isPreludeImported
     isPreludeImported = not (null (do
       importDecl <- importDecls
-      guard (sModuleName (importModule importDecl) == preludeModuleName)))
+      guard (dropAnn (importModule importDecl) == preludeModuleName)))
     preludeSymbols = fromMaybe [] (Map.lookup preludeModuleName environment)
     (_, extensions) = getModuleExtensions modul
 
-preludeModuleName :: UnAnn.ModuleName
-preludeModuleName = UnAnn.ModuleName "Prelude"
+preludeModuleName :: ModuleName ()
+preludeModuleName = ModuleName () "Prelude"
 
 importDeclTable :: Environment -> ImportDecl l -> Global.Table
 importDeclTable environment importDecl =
   computeSymbolTable isQualified moduleName importSymbols where
     ImportDecl _ importModuleName isQualified _ _ _ maybeAs maybeImportSpecList =
       importDecl
-    moduleName = sModuleName (fromMaybe importModuleName maybeAs)
+    moduleName = dropAnn (fromMaybe importModuleName maybeAs)
     importSymbols = case maybeImportSpecList of
       Nothing ->
         importModuleSymbols
       Just importSpecList ->
         importSpecListSymbols importModuleName importModuleSymbols importSpecList
     importModuleSymbols = fromMaybe [] (
-      Map.lookup (sModuleName importModuleName) environment)
+      Map.lookup (dropAnn importModuleName) environment)
 
 
 importSpecListSymbols :: ModuleName l -> [Symbol] -> ImportSpecList l -> [Symbol]
@@ -101,7 +99,7 @@ annotateImportDecl moduleName environment importDecl = importDecl' where
     maybeAs
     maybeImportSpecList = importDecl
 
-  importDecl' = case Map.lookup (sModuleName importModuleName) environment of
+  importDecl' = case Map.lookup (dropAnn importModuleName) environment of
     Nothing -> scopeError (EModNotFound importModuleName) importDecl
     Just symbols ->
       ImportDecl
@@ -123,7 +121,7 @@ annotateImportDecl moduleName environment importDecl = importDecl' where
               ScopeError e
             _ -> Import table
           table = computeSymbolTable isQualified qualificationName importSymbols
-          qualificationName = sModuleName (fromMaybe importModuleName maybeAs)
+          qualificationName = dropAnn (fromMaybe importModuleName maybeAs)
           importSymbols =
             maybe
               symbols
@@ -237,7 +235,7 @@ resolveImportSpec mod isHiding symbols spec =
           cns'
   where
     (~~) :: Symbol -> Name l -> Bool
-    symbol ~~ name = symbolName symbol == sName name
+    symbol ~~ name = symbolName symbol == dropAnn name
 
     isConstructor :: Symbol -> Bool
     isConstructor Constructor {} = True

--- a/src/Language/Haskell/Names/LocalSymbolTable.hs
+++ b/src/Language/Haskell/Names/LocalSymbolTable.hs
@@ -9,23 +9,22 @@ module Language.Haskell.Names.LocalSymbolTable
 
 import qualified Data.Map as Map
 import Data.Monoid
-import Language.Haskell.Exts (Name)
-import Language.Haskell.Exts.Annotated.Simplify (sName)
-import qualified Language.Haskell.Exts.Annotated as Ann
+import Language.Haskell.Exts
+import Language.Haskell.Names.SyntaxUtils (dropAnn)
 import Language.Haskell.Names.Types
 
 -- | Local symbol table — contains locally bound names
-newtype Table = Table (Map.Map Name Ann.SrcLoc)
+newtype Table = Table (Map.Map (Name ()) SrcLoc)
   deriving Monoid
 
-addValue :: Ann.SrcInfo l => Ann.Name l -> Table -> Table
+addValue :: SrcInfo l => Name l -> Table -> Table
 addValue n (Table vs) =
-  Table (Map.insert (sName n) (Ann.getPointLoc $ Ann.ann n) vs)
+  Table (Map.insert (dropAnn n) (getPointLoc $ ann n) vs)
 
-lookupValue :: Ann.QName l -> Table -> Either (Error l) Ann.SrcLoc
-lookupValue qn@(Ann.UnQual _ n) (Table vs) =
+lookupValue :: QName l -> Table -> Either (Error l) SrcLoc
+lookupValue qn@(UnQual _ n) (Table vs) =
   maybe (Left $ ENotInScope qn) Right $
-    Map.lookup (sName n) vs
+    Map.lookup (dropAnn n) vs
 lookupValue qn _ = Left $ ENotInScope qn
 
 empty :: Table

--- a/src/Language/Haskell/Names/Open/Base.hs
+++ b/src/Language/Haskell/Names/Open/Base.hs
@@ -11,8 +11,8 @@ import qualified Language.Haskell.Names.GlobalSymbolTable as Global
 import qualified Language.Haskell.Names.LocalSymbolTable as Local
 import Language.Haskell.Names.GetBound
 import Language.Haskell.Names.RecordWildcards
-import Language.Haskell.Exts.Annotated
-import qualified Language.Haskell.Exts.Syntax as UnAnn
+import Language.Haskell.Exts
+import Language.Haskell.Exts.Syntax
 import Control.Applicative
 import Control.Monad.Identity
 import Data.List
@@ -48,7 +48,7 @@ data Scope = Scope
   { _gTable :: Global.Table
   , _lTable :: Local.Table
   , _nameCtx :: NameContext
-  , _instQual :: Maybe UnAnn.ModuleName
+  , _instQual :: Maybe (ModuleName ())
   , _wcNames :: WcNames
   }
 
@@ -151,5 +151,5 @@ exprUV = setNameCtx ReferenceUV
 exprUT :: Scope -> Scope
 exprUT = setNameCtx ReferenceUT
 
-instQ :: Maybe UnAnn.ModuleName -> Scope -> Scope
+instQ :: Maybe (ModuleName ()) -> Scope -> Scope
 instQ m = setL instQual m

--- a/src/Language/Haskell/Names/Open/Derived.hs
+++ b/src/Language/Haskell/Names/Open/Derived.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell, MultiParamTypeClasses, FlexibleInstances, ConstraintKinds, UndecidableInstances #-}
 module Language.Haskell.Names.Open.Derived where
 
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 import Data.Generics.Traversable.TH
 
 deriveGTraversable ''ModuleName
@@ -150,3 +150,11 @@ deriveGTraversable ''Namespace
 deriveGTraversable ''PatternSynDirection
 
 deriveGTraversable ''Role
+
+deriveGTraversable ''InjectivityInfo
+
+deriveGTraversable ''ResultSig
+
+deriveGTraversable ''Unpackedness
+
+deriveGTraversable ''EWildcard

--- a/src/Language/Haskell/Names/Open/Instances.hs
+++ b/src/Language/Haskell/Names/Open/Instances.hs
@@ -15,7 +15,7 @@ import Language.Haskell.Names.Open.Base
 import Language.Haskell.Names.Open.Derived ()
 import Language.Haskell.Names.GetBound
 import Language.Haskell.Names.RecordWildcards
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 import Language.Haskell.Names.SyntaxUtils
 import qualified Data.Data as D
 import Control.Applicative

--- a/src/Language/Haskell/Names/Recursive.hs
+++ b/src/Language/Haskell/Names/Recursive.hs
@@ -11,8 +11,7 @@ import Control.Monad (forM, forM_, unless)
 
 import qualified Data.Map as Map (insert)
 import Control.Monad.State.Strict (State, execState, get, modify)
-import Language.Haskell.Exts.Annotated
-import Language.Haskell.Exts.Annotated.Simplify (sModuleName)
+import Language.Haskell.Exts
 
 import Language.Haskell.Names.Types
 import Language.Haskell.Names.SyntaxUtils
@@ -50,7 +49,7 @@ findFixPoint :: (Data l, Eq l) => [Module l] -> State Environment ()
 findFixPoint modules = loop (replicate (length modules) []) where
   loop modulesSymbols = do
     forM_ (zip modules modulesSymbols) (\(modul, symbols) -> do
-      modify (Map.insert (sModuleName (getModuleName modul)) symbols))
+      modify (Map.insert (dropAnn (getModuleName modul)) symbols))
     environment <- get
     modulesSymbols' <- forM modules (\modul -> do
       let globalTable = moduleTable (importTable environment modul) modul

--- a/src/Language/Haskell/Names/ScopeUtils.hs
+++ b/src/Language/Haskell/Names/ScopeUtils.hs
@@ -6,8 +6,6 @@ import Data.Monoid
 import Language.Haskell.Names.Types
 import Language.Haskell.Names.SyntaxUtils
 import Language.Haskell.Exts
-import Language.Haskell.Exts.Annotated.Simplify (sName)
-import qualified Language.Haskell.Exts.Annotated as Ann
 import qualified Language.Haskell.Names.GlobalSymbolTable as Global
 import Control.Monad (guard)
 import Data.List (nub)
@@ -18,10 +16,10 @@ scopeError e f = Scoped (ScopeError e) <$> f
 none :: l -> Scoped l
 none = Scoped None
 
-noScope :: (Ann.Annotated a) => a l -> a (Scoped l)
+noScope :: (Annotated a) => a l -> a (Scoped l)
 noScope = fmap none
 
-symbolParent :: Symbol -> Maybe Name
+symbolParent :: Symbol -> Maybe (Name ())
 symbolParent (Selector { typeName = n }) = Just n
 symbolParent (Constructor { typeName = n }) = Just n
 symbolParent (Method { className = n }) = Just n
@@ -35,47 +33,47 @@ computeSymbolTable
     -- inserted.
     --
     -- If 'False', then both qualified and unqualified names are insterted.
-  -> ModuleName
+  -> ModuleName ()
   -> [Symbol]
   -> Global.Table
 computeSymbolTable qual modulename symbols =
   Global.fromList (qualified <> if qual then [] else unqualified) where
     qualified = do
         symbol <- symbols
-        return (Qual modulename (symbolName symbol),symbol)
+        return (Qual () modulename (symbolName symbol),symbol)
     unqualified = do
         symbol <- symbols
-        return (UnQual (symbolName symbol),symbol)
+        return (UnQual () (symbolName symbol),symbol)
 
 -- | Find a single constructor or method name in a list of symbols
 resolveCName
   :: [Symbol]
-  -> Name
-  -> (Ann.CName l -> Error l) -- ^ error for "not found" condition
-  -> Ann.CName l
-  -> (Ann.CName (Scoped l), [Symbol])
+  -> Name ()
+  -> (CName l -> Error l) -- ^ error for "not found" condition
+  -> CName l
+  -> (CName (Scoped l), [Symbol])
 resolveCName symbols parent notFound cn =
   let
     vs = nub (do
         symbol <- symbols
         guard (Global.isValue symbol)
         let name = symbolName symbol
-        guard (sName (unCName cn) == name)
+        guard (dropAnn (unCName cn) == name)
         Just p <- return $ symbolParent symbol
         guard (p == parent)
         return symbol)
   in
     case vs of
       [] -> (scopeError (notFound cn) cn, [])
-      [symbol] -> (Scoped (GlobalSymbol symbol (UnQual (sName (unCName cn)))) <$> cn, [symbol])
+      [symbol] -> (Scoped (GlobalSymbol symbol (UnQual () (dropAnn (unCName cn)))) <$> cn, [symbol])
       _ -> (scopeError (EInternal "resolveCName") cn, [])
 
 -- | Find a list of constructor or method names in a list of symbols.
 resolveCNames
   :: [Symbol]
-  -> Name
-  -> (Ann.CName l -> Error l) -- ^ error for "not found" condition
-  -> [Ann.CName l]
-  -> ([Ann.CName (Scoped l)], [Symbol])
+  -> Name ()
+  -> (CName l -> Error l) -- ^ error for "not found" condition
+  -> [CName l]
+  -> ([CName (Scoped l)], [Symbol])
 resolveCNames syms orig notFound =
   second mconcat . unzip . map (resolveCName syms orig notFound)

--- a/src/Language/Haskell/Names/SyntaxUtils.hs
+++ b/src/Language/Haskell/Names/SyntaxUtils.hs
@@ -26,8 +26,8 @@ import Data.Char
 import Data.Either
 import Data.Foldable hiding (elem)
 import qualified Data.Set as Set
-import qualified Language.Haskell.Exts as UnAnn
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
+import Language.Haskell.Exts.Extension
 import Language.Haskell.Names.Types
 
 dropAnn :: (Functor a) => a l -> a ()
@@ -36,17 +36,16 @@ dropAnn = fmap (const ())
 setAnn :: (Functor a) => l' -> a l -> a l'
 setAnn l = fmap (const l)
 
-annName :: UnAnn.Name -> Name ()
-annName (UnAnn.Ident n) = Ident () n
-annName (UnAnn.Symbol n) = Symbol () n
+annName :: a -> a
+annName = id
 
-nameQualification :: QName l -> Maybe UnAnn.ModuleName
+nameQualification :: QName l -> Maybe (ModuleName ())
 nameQualification (UnQual _ _) =
   Nothing
 nameQualification (Special _ _) =
   Nothing
 nameQualification (Qual _ (ModuleName _ moduleName) _) =
-  Just (UnAnn.ModuleName moduleName)
+  Just (ModuleName () moduleName)
 
 getModuleName :: Module l -> ModuleName l
 getModuleName (Module _ (Just (ModuleHead _ mn _ _)) _ _ _) = mn
@@ -90,7 +89,7 @@ getImportDecls (XmlHybrid _ _ _ is _ _ _ _ _) = is
 
 getDeclHead :: Decl l -> Maybe (DeclHead l)
 getDeclHead (TypeDecl _ dhead _) = Just dhead
-getDeclHead (TypeFamDecl _ dhead _) = Just dhead
+getDeclHead (TypeFamDecl _ dhead _ _) = Just dhead
 getDeclHead (DataDecl _ _ _ dhead _ _) = Just dhead
 getDeclHead (GDataDecl _ _ _ dhead _ _ _) = Just dhead
 getDeclHead (DataFamDecl _ _ dhead _) = Just dhead
@@ -109,7 +108,7 @@ getDeclHeadName dh =
 
 isTypeDecl :: Decl l -> Bool
 isTypeDecl (TypeDecl _ _ _) = True
-isTypeDecl (TypeFamDecl _ _ _) = True
+isTypeDecl (TypeFamDecl _ _ _ _) = True
 isTypeDecl (DataDecl _ _ _ _ _ _) = True
 isTypeDecl (GDataDecl _ _ _ _ _ _ _) = True
 isTypeDecl (DataFamDecl _ _ _ _) = True

--- a/tests/exports/DataFamilies.hs.golden
+++ b/tests/exports/DataFamilies.hs.golden
@@ -1,30 +1,30 @@
 [ DataFam
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "Vector"
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "Vector"
     , associate = Nothing
     }
 , Class
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "ListLike"
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "ListLike"
     }
 , TypeFam
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "I"
-    , associate = Just (Ident "ListLike")
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "I"
+    , associate = Just (Ident () "ListLike")
     }
 , Method
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "method1"
-    , className = Ident "ListLike"
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "method1"
+    , className = Ident () "ListLike"
     }
 , DataFam
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "Vector"
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "Vector"
     , associate = Nothing
     }
 , Constructor
-    { symbolModule = ModuleName "DataFamilies"
-    , symbolName = Ident "U_Vector"
-    , typeName = Ident "Vector"
+    { symbolModule = ModuleName () "DataFamilies"
+    , symbolName = Ident () "U_Vector"
+    , typeName = Ident () "Vector"
     }
 ]

--- a/tests/exports/ExportList.hs.golden
+++ b/tests/exports/ExportList.hs.golden
@@ -1,3 +1,5 @@
 [ Data
-    { symbolModule = ModuleName "ExportList" , symbolName = Ident "A" }
+    { symbolModule = ModuleName () "ExportList"
+    , symbolName = Ident () "A"
+    }
 ]

--- a/tests/exports/ExportList2.hs.golden
+++ b/tests/exports/ExportList2.hs.golden
@@ -1,11 +1,11 @@
 [ Selector
-    { symbolModule = ModuleName "ExportList2"
-    , symbolName = Ident "b"
-    , typeName = Ident "A"
-    , constructors = [ Ident "B" , Ident "A" ]
+    { symbolModule = ModuleName () "ExportList2"
+    , symbolName = Ident () "b"
+    , typeName = Ident () "A"
+    , constructors = [ Ident () "B" , Ident () "A" ]
     }
 , Value
-    { symbolModule = ModuleName "ExportList2"
-    , symbolName = Ident "c"
+    { symbolModule = ModuleName () "ExportList2"
+    , symbolName = Ident () "c"
     }
 ]

--- a/tests/exports/ExportListMembers.hs.golden
+++ b/tests/exports/ExportListMembers.hs.golden
@@ -1,39 +1,39 @@
 [ Data
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "Foo"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "Foo1"
-    , typeName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "Foo1"
+    , typeName = Ident () "Foo"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "Foo3"
-    , typeName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "Foo3"
+    , typeName = Ident () "Foo"
     }
 , Selector
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "c"
-    , typeName = Ident "Foo"
-    , constructors = [ Ident "Foo2" ]
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "c"
+    , typeName = Ident () "Foo"
+    , constructors = [ Ident () "Foo2" ]
     }
 , Class
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "Bar"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "Bar"
     }
 , Method
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "x"
-    , className = Ident "Bar"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "x"
+    , className = Ident () "Bar"
     }
 , NewType
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "N"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "N"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListMembers"
-    , symbolName = Ident "N"
-    , typeName = Ident "N"
+    { symbolModule = ModuleName () "ExportListMembers"
+    , symbolName = Ident () "N"
+    , typeName = Ident () "N"
     }
 ]

--- a/tests/exports/ExportListWildcards.hs.golden
+++ b/tests/exports/ExportListWildcards.hs.golden
@@ -1,50 +1,50 @@
 [ Data
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "Foo"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "Foo1"
-    , typeName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "Foo1"
+    , typeName = Ident () "Foo"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "Foo2"
-    , typeName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "Foo2"
+    , typeName = Ident () "Foo"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "Foo3"
-    , typeName = Ident "Foo"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "Foo3"
+    , typeName = Ident () "Foo"
     }
 , Selector
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "c"
-    , typeName = Ident "Foo"
-    , constructors = [ Ident "Foo3" ]
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "c"
+    , typeName = Ident () "Foo"
+    , constructors = [ Ident () "Foo3" ]
     }
 , Class
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "Bar"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "Bar"
     }
 , Method
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "x"
-    , className = Ident "Bar"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "x"
+    , className = Ident () "Bar"
     }
 , NewType
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "N"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "N"
     }
 , Constructor
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "N"
-    , typeName = Ident "N"
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "N"
+    , typeName = Ident () "N"
     }
 , Selector
-    { symbolModule = ModuleName "ExportListWildcards"
-    , symbolName = Ident "unN"
-    , typeName = Ident "N"
-    , constructors = [ Ident "N" ]
+    { symbolModule = ModuleName () "ExportListWildcards"
+    , symbolName = Ident () "unN"
+    , typeName = Ident () "N"
+    , constructors = [ Ident () "N" ]
     }
 ]

--- a/tests/exports/ImplicitExportList.hs.golden
+++ b/tests/exports/ImplicitExportList.hs.golden
@@ -1,3 +1,5 @@
 [ Value
-    { symbolModule = ModuleName "Main" , symbolName = Ident "main" }
+    { symbolModule = ModuleName () "Main"
+    , symbolName = Ident () "main"
+    }
 ]

--- a/tests/exports/ModuleReExport.hs.golden
+++ b/tests/exports/ModuleReExport.hs.golden
@@ -1,82 +1,82 @@
 [ Value
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "function"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "function"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method1"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method1"
+    , className = Ident () "Class"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method2"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method2"
+    , className = Ident () "Class"
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector1"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector1"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector2"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector2"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "unNewtype"
-    , typeName = Ident "NewtypeWithSelectors"
-    , constructors = [ Ident "NewtypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "unNewtype"
+    , typeName = Ident () "NewtypeWithSelectors"
+    , constructors = [ Ident () "NewtypeWithSelectors" ]
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor1"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor1"
+    , typeName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor2"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor2"
+    , typeName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
-    , typeName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
+    , typeName = Ident () "DataTypeWithSelectors"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
-    , typeName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
+    , typeName = Ident () "Newtype"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
-    , typeName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
+    , typeName = Ident () "NewtypeWithSelectors"
     }
 , Type
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "TypeSynonym"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "TypeSynonym"
     }
 , Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataType"
     }
 , Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
     }
 , Class
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Class"
     }
 ]

--- a/tests/exports/Prelude.hs.golden
+++ b/tests/exports/Prelude.hs.golden
@@ -1,82 +1,82 @@
 [ Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor1"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor1"
+    , typeName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor2"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor2"
+    , typeName = Ident () "DataType"
     }
 , Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
-    , typeName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
+    , typeName = Ident () "DataTypeWithSelectors"
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector1"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector1"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector2"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector2"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
-    , typeName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
+    , typeName = Ident () "Newtype"
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
-    , typeName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
+    , typeName = Ident () "NewtypeWithSelectors"
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "unNewtype"
-    , typeName = Ident "NewtypeWithSelectors"
-    , constructors = [ Ident "NewtypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "unNewtype"
+    , typeName = Ident () "NewtypeWithSelectors"
+    , constructors = [ Ident () "NewtypeWithSelectors" ]
     }
 , Type
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "TypeSynonym"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "TypeSynonym"
     }
 , Class
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Class"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method1"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method1"
+    , className = Ident () "Class"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method2"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method2"
+    , className = Ident () "Class"
     }
 , Value
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "function"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "function"
     }
 ]

--- a/tests/exports/Rec1.hs.golden
+++ b/tests/exports/Rec1.hs.golden
@@ -1,9 +1,17 @@
 [ Value
-    { symbolModule = ModuleName "Rec1" , symbolName = Ident "rec1_1" }
+    { symbolModule = ModuleName () "Rec1"
+    , symbolName = Ident () "rec1_1"
+    }
 , Value
-    { symbolModule = ModuleName "Rec1" , symbolName = Ident "rec1_2" }
+    { symbolModule = ModuleName () "Rec1"
+    , symbolName = Ident () "rec1_2"
+    }
 , Value
-    { symbolModule = ModuleName "Rec2" , symbolName = Ident "rec2" }
+    { symbolModule = ModuleName () "Rec2"
+    , symbolName = Ident () "rec2"
+    }
 , Value
-    { symbolModule = ModuleName "Rec3" , symbolName = Ident "rec3" }
+    { symbolModule = ModuleName () "Rec3"
+    , symbolName = Ident () "rec3"
+    }
 ]

--- a/tests/exports/Rec2.hs.golden
+++ b/tests/exports/Rec2.hs.golden
@@ -1,7 +1,13 @@
 [ Value
-    { symbolModule = ModuleName "Rec2" , symbolName = Ident "rec2" }
+    { symbolModule = ModuleName () "Rec2"
+    , symbolName = Ident () "rec2"
+    }
 , Value
-    { symbolModule = ModuleName "Rec1" , symbolName = Ident "rec1_1" }
+    { symbolModule = ModuleName () "Rec1"
+    , symbolName = Ident () "rec1_1"
+    }
 , Value
-    { symbolModule = ModuleName "Rec3" , symbolName = Ident "rec3" }
+    { symbolModule = ModuleName () "Rec3"
+    , symbolName = Ident () "rec3"
+    }
 ]

--- a/tests/exports/Rec3.hs.golden
+++ b/tests/exports/Rec3.hs.golden
@@ -1,7 +1,13 @@
 [ Value
-    { symbolModule = ModuleName "Rec1" , symbolName = Ident "rec1_1" }
+    { symbolModule = ModuleName () "Rec1"
+    , symbolName = Ident () "rec1_1"
+    }
 , Value
-    { symbolModule = ModuleName "Rec1" , symbolName = Ident "rec1_2" }
+    { symbolModule = ModuleName () "Rec1"
+    , symbolName = Ident () "rec1_2"
+    }
 , Value
-    { symbolModule = ModuleName "Rec3" , symbolName = Ident "rec3" }
+    { symbolModule = ModuleName () "Rec3"
+    , symbolName = Ident () "rec3"
+    }
 ]

--- a/tests/exports/SelfReExport.hs.golden
+++ b/tests/exports/SelfReExport.hs.golden
@@ -1,90 +1,90 @@
 [ Value
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "function"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "function"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method1"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method1"
+    , className = Ident () "Class"
     }
 , Method
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "method2"
-    , className = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "method2"
+    , className = Ident () "Class"
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector1"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector1"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "selector2"
-    , typeName = Ident "DataTypeWithSelectors"
-    , constructors = [ Ident "DataTypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "selector2"
+    , typeName = Ident () "DataTypeWithSelectors"
+    , constructors = [ Ident () "DataTypeWithSelectors" ]
     }
 , Selector
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "unNewtype"
-    , typeName = Ident "NewtypeWithSelectors"
-    , constructors = [ Ident "NewtypeWithSelectors" ]
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "unNewtype"
+    , typeName = Ident () "NewtypeWithSelectors"
+    , constructors = [ Ident () "NewtypeWithSelectors" ]
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor1"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor1"
+    , typeName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Constructor2"
-    , typeName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Constructor2"
+    , typeName = Ident () "DataType"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
-    , typeName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
+    , typeName = Ident () "DataTypeWithSelectors"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
-    , typeName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
+    , typeName = Ident () "Newtype"
     }
 , Constructor
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
-    , typeName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
+    , typeName = Ident () "NewtypeWithSelectors"
     }
 , Type
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "TypeSynonym"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "TypeSynonym"
     }
 , Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataType"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataType"
     }
 , Data
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "DataTypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "DataTypeWithSelectors"
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Newtype"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Newtype"
     }
 , NewType
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "NewtypeWithSelectors"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "NewtypeWithSelectors"
     }
 , Class
-    { symbolModule = ModuleName "Prelude"
-    , symbolName = Ident "Class"
+    { symbolModule = ModuleName () "Prelude"
+    , symbolName = Ident () "Class"
     }
 , Value
-    { symbolModule = ModuleName "SelfReExport"
-    , symbolName = Ident "local"
+    { symbolModule = ModuleName () "SelfReExport"
+    , symbolName = Ident () "local"
     }
 , Data
-    { symbolModule = ModuleName "SelfReExport"
-    , symbolName = Ident "Local"
+    { symbolModule = ModuleName () "SelfReExport"
+    , symbolName = Ident () "Local"
     }
 ]

--- a/tests/exports/SimpleData.hs.golden
+++ b/tests/exports/SimpleData.hs.golden
@@ -1,8 +1,10 @@
 [ Data
-    { symbolModule = ModuleName "SimpleData" , symbolName = Ident "A" }
+    { symbolModule = ModuleName () "SimpleData"
+    , symbolName = Ident () "A"
+    }
 , Constructor
-    { symbolModule = ModuleName "SimpleData"
-    , symbolName = Ident "A"
-    , typeName = Ident "A"
+    { symbolModule = ModuleName () "SimpleData"
+    , symbolName = Ident () "A"
+    , typeName = Ident () "A"
     }
 ]

--- a/tests/exports/SimpleTypes.hs.golden
+++ b/tests/exports/SimpleTypes.hs.golden
@@ -1,29 +1,29 @@
 [ Data
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "A"
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "A"
     }
 , Constructor
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "B"
-    , typeName = Ident "A"
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "B"
+    , typeName = Ident () "A"
     }
 , Selector
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "c"
-    , typeName = Ident "A"
-    , constructors = [ Ident "B" ]
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "c"
+    , typeName = Ident () "A"
+    , constructors = [ Ident () "B" ]
     }
 , NewType
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "G"
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "G"
     }
 , Constructor
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "H"
-    , typeName = Ident "G"
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "H"
+    , typeName = Ident () "G"
     }
 , Type
-    { symbolModule = ModuleName "SimpleTypes"
-    , symbolName = Ident "L"
+    { symbolModule = ModuleName () "SimpleTypes"
+    , symbolName = Ident () "L"
     }
 ]

--- a/tests/exports/SimpleValue.hs.golden
+++ b/tests/exports/SimpleValue.hs.golden
@@ -1,5 +1,5 @@
 [ Value
-    { symbolModule = ModuleName "SimpleValue"
-    , symbolName = Ident "a"
+    { symbolModule = ModuleName () "SimpleValue"
+    , symbolName = Ident () "a"
     }
 ]

--- a/tests/imports/ExplicitPreludeQualified.hs.golden
+++ b/tests/imports/ExplicitPreludeQualified.hs.golden
@@ -1,124 +1,126 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Class")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Class")
     , [ Class
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataType")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataTypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Newtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Newtype")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "NewtypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "NewtypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
-          , typeName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
+          , typeName = Ident () "NewtypeWithSelectors"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "TypeSynonym")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "function")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method1")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method1"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method1"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector2")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector2"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector2"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "unNewtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "unNewtype")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "unNewtype"
-          , typeName = Ident "NewtypeWithSelectors"
-          , constructors = [ Ident "NewtypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "unNewtype"
+          , typeName = Ident () "NewtypeWithSelectors"
+          , constructors = [ Ident () "NewtypeWithSelectors" ]
           }
       ]
     )

--- a/tests/imports/Hiding.hs.golden
+++ b/tests/imports/Hiding.hs.golden
@@ -1,117 +1,118 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Constructor2")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataType")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataTypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "TypeSynonym")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "function")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "Constructor2")
+  , ( UnQual () (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataType")
+  , ( UnQual () (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataTypeWithSelectors")
+  , ( UnQual () (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( UnQual (Ident "TypeSynonym")
+  , ( UnQual () (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( UnQual (Ident "function")
+  , ( UnQual () (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( UnQual (Ident "method2")
+  , ( UnQual () (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "selector1")
+  , ( UnQual () (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )

--- a/tests/imports/ImplicitPrelude.hs.golden
+++ b/tests/imports/ImplicitPrelude.hs.golden
@@ -1,247 +1,249 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Class")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Class")
     , [ Class
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataType")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataTypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Newtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Newtype")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "NewtypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "NewtypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
-          , typeName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
+          , typeName = Ident () "NewtypeWithSelectors"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "TypeSynonym")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "function")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method1")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method1"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method1"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector2")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector2"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector2"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "unNewtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "unNewtype")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "unNewtype"
-          , typeName = Ident "NewtypeWithSelectors"
-          , constructors = [ Ident "NewtypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "unNewtype"
+          , typeName = Ident () "NewtypeWithSelectors"
+          , constructors = [ Ident () "NewtypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "Class")
+  , ( UnQual () (Ident () "Class")
     , [ Class
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor1")
+  , ( UnQual () (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor2")
+  , ( UnQual () (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataType")
+  , ( UnQual () (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataTypeWithSelectors")
+  , ( UnQual () (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( UnQual (Ident "Newtype")
+  , ( UnQual () (Ident () "Newtype")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( UnQual (Ident "NewtypeWithSelectors")
+  , ( UnQual () (Ident () "NewtypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
-          , typeName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
+          , typeName = Ident () "NewtypeWithSelectors"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
           }
       ]
     )
-  , ( UnQual (Ident "TypeSynonym")
+  , ( UnQual () (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( UnQual (Ident "function")
+  , ( UnQual () (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( UnQual (Ident "method1")
+  , ( UnQual () (Ident () "method1")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method1"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method1"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "method2")
+  , ( UnQual () (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "selector1")
+  , ( UnQual () (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "selector2")
+  , ( UnQual () (Ident () "selector2")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector2"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector2"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "unNewtype")
+  , ( UnQual () (Ident () "unNewtype")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "unNewtype"
-          , typeName = Ident "NewtypeWithSelectors"
-          , constructors = [ Ident "NewtypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "unNewtype"
+          , typeName = Ident () "NewtypeWithSelectors"
+          , constructors = [ Ident () "NewtypeWithSelectors" ]
           }
       ]
     )

--- a/tests/imports/ImportAll.hs.golden
+++ b/tests/imports/ImportAll.hs.golden
@@ -1,25 +1,25 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Newtype")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Newtype")
     , [ NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       , Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       ]
     )
-  , ( UnQual (Ident "Newtype")
+  , ( UnQual () (Ident () "Newtype")
     , [ NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       , Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       ]
     )

--- a/tests/imports/ImportList.hs.golden
+++ b/tests/imports/ImportList.hs.golden
@@ -1,75 +1,75 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Constructor1")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataType")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Newtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Newtype")
     , [ NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "function")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor1")
+  , ( UnQual () (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor2")
+  , ( UnQual () (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataType")
+  , ( UnQual () (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "Newtype")
+  , ( UnQual () (Ident () "Newtype")
     , [ NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( UnQual (Ident "function")
+  , ( UnQual () (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )

--- a/tests/imports/SimpleImport.hs.golden
+++ b/tests/imports/SimpleImport.hs.golden
@@ -1,247 +1,249 @@
 fromList
-  [ ( Qual (ModuleName "Prelude") (Ident "Class")
+  [ ( Qual () (ModuleName () "Prelude") (Ident () "Class")
     , [ Class
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Constructor2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataType")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "DataTypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "Newtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "Newtype")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "NewtypeWithSelectors")
+  , ( Qual
+        () (ModuleName () "Prelude") (Ident () "NewtypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
-          , typeName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
+          , typeName = Ident () "NewtypeWithSelectors"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "TypeSynonym")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "function")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method1")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method1"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method1"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "method2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector1")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "selector2")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "selector2")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector2"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector2"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( Qual (ModuleName "Prelude") (Ident "unNewtype")
+  , ( Qual () (ModuleName () "Prelude") (Ident () "unNewtype")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "unNewtype"
-          , typeName = Ident "NewtypeWithSelectors"
-          , constructors = [ Ident "NewtypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "unNewtype"
+          , typeName = Ident () "NewtypeWithSelectors"
+          , constructors = [ Ident () "NewtypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "Class")
+  , ( UnQual () (Ident () "Class")
     , [ Class
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor1")
+  , ( UnQual () (Ident () "Constructor1")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor1"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor1"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "Constructor2")
+  , ( UnQual () (Ident () "Constructor2")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Constructor2"
-          , typeName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Constructor2"
+          , typeName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataType")
+  , ( UnQual () (Ident () "DataType")
     , [ Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataType"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataType"
           }
       ]
     )
-  , ( UnQual (Ident "DataTypeWithSelectors")
+  , ( UnQual () (Ident () "DataTypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
-          , typeName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
+          , typeName = Ident () "DataTypeWithSelectors"
           }
       , Data
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "DataTypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "DataTypeWithSelectors"
           }
       ]
     )
-  , ( UnQual (Ident "Newtype")
+  , ( UnQual () (Ident () "Newtype")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
-          , typeName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
+          , typeName = Ident () "Newtype"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "Newtype"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "Newtype"
           }
       ]
     )
-  , ( UnQual (Ident "NewtypeWithSelectors")
+  , ( UnQual () (Ident () "NewtypeWithSelectors")
     , [ Constructor
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
-          , typeName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
+          , typeName = Ident () "NewtypeWithSelectors"
           }
       , NewType
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "NewtypeWithSelectors"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "NewtypeWithSelectors"
           }
       ]
     )
-  , ( UnQual (Ident "TypeSynonym")
+  , ( UnQual () (Ident () "TypeSynonym")
     , [ Type
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "TypeSynonym"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "TypeSynonym"
           }
       ]
     )
-  , ( UnQual (Ident "function")
+  , ( UnQual () (Ident () "function")
     , [ Value
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "function"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "function"
           }
       ]
     )
-  , ( UnQual (Ident "method1")
+  , ( UnQual () (Ident () "method1")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method1"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method1"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "method2")
+  , ( UnQual () (Ident () "method2")
     , [ Method
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "method2"
-          , className = Ident "Class"
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "method2"
+          , className = Ident () "Class"
           }
       ]
     )
-  , ( UnQual (Ident "selector1")
+  , ( UnQual () (Ident () "selector1")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector1"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector1"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "selector2")
+  , ( UnQual () (Ident () "selector2")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "selector2"
-          , typeName = Ident "DataTypeWithSelectors"
-          , constructors = [ Ident "DataTypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "selector2"
+          , typeName = Ident () "DataTypeWithSelectors"
+          , constructors = [ Ident () "DataTypeWithSelectors" ]
           }
       ]
     )
-  , ( UnQual (Ident "unNewtype")
+  , ( UnQual () (Ident () "unNewtype")
     , [ Selector
-          { symbolModule = ModuleName "Prelude"
-          , symbolName = Ident "unNewtype"
-          , typeName = Ident "NewtypeWithSelectors"
-          , constructors = [ Ident "NewtypeWithSelectors" ]
+          { symbolModule = ModuleName () "Prelude"
+          , symbolName = Ident () "unNewtype"
+          , typeName = Ident () "NewtypeWithSelectors"
+          , constructors = [ Ident () "NewtypeWithSelectors" ]
           }
       ]
     )

--- a/tests/run.hs
+++ b/tests/run.hs
@@ -22,8 +22,8 @@ import Text.Show.Pretty (ppShow)
 import Text.Printf
 import qualified Data.Foldable as F
 
-import Language.Haskell.Exts.Annotated hiding (NewType)
-import qualified Language.Haskell.Exts.Annotated as Syntax (DataOrNew(NewType))
+import Language.Haskell.Exts hiding (DataOrNew(NewType))
+import qualified Language.Haskell.Exts.Syntax as Syntax (DataOrNew(NewType))
 import qualified Language.Haskell.Exts as U (ModuleName(ModuleName))
 import Language.Haskell.Names
 import Language.Haskell.Names.Exports
@@ -96,7 +96,7 @@ environmentTests :: TestTree
 environmentTests = goldenTest path run where
   run = do
     baseEnvironment <- loadBase
-    writeSymbols out (baseEnvironment Map.! (U.ModuleName "Prelude"))
+    writeSymbols out (baseEnvironment Map.! (U.ModuleName () "Prelude"))
   path = "tests/environment/Prelude.symbols"
   out = path <.> "out"
 


### PR DESCRIPTION
This enormous patch makes haskell-names work with https://github.com/mpickering/haskell-src-exts/tree/one-ast.  Hopefully it will be helpful if and when that version becomes the official release.  The proposal is to eliminate the simplified types and only provides the annotated types. Here are my notes about the changes:

0. Change all imports of Language.Haskell.Exts.Annotated.* to Language.Haskell.Exts.*

1. all the Simplified functions are replaced by calls to dropAnn

2. All the Simplified types are replaced by the corresponding annotated type with the type parameter ().

3. There is a new EWildcard argument, and EThingWith now subsumes the EThingAll constructor.  I turned the EThingAll case into an EThingWith case with suitable arguments for the (..) case.  I think there is more to do here to handle all the possible EThingWith values.  (see Exports.hs)

4. New field of TypeFamDecl constructor - ignored like the others

5. New field of TyBang constructor - ignored like the others

6. New field of ClsTyFam constructor - ignored like the others

7. Added new calls to deriveGTraversable for types InjectivityInfo, ResultSig, Unpackedness, and EWildcard

8. Updated test case, one still doesn't work because it looks for a file I don't have.
