### PR TITLE
Added pattern synonym

### DIFF
--- a/src/Language/Haskell/Names/Environment.hs
+++ b/src/Language/Haskell/Names/Environment.hs
@@ -84,6 +84,7 @@ symbolEntity i = case i of
   TypeFam {} -> "typeFamily"
   DataFam {} -> "dataFamily"
   Class   {} -> "class"
+  PatSyn {} -> "patSyn"
 
 parseName :: String -> Name ()
 parseName = dropAnn . stringToName
@@ -116,6 +117,7 @@ instance FromJSON Symbol where
         associate <- fmap parseName <$> v .: "associate"
         return $ DataFam symbolmodule symbolname associate
       "class" -> return $ Class symbolmodule symbolname
+      "patSyn" -> return $ PatSyn symbolmodule symbolname
       _ -> mzero
 
   parseJSON _ = mzero

--- a/src/Language/Haskell/Names/Exports.hs
+++ b/src/Language/Haskell/Names/Exports.hs
@@ -6,7 +6,6 @@ module Language.Haskell.Names.Exports
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Control.Applicative
 import Control.Monad
 import Control.Monad.Writer
 import Data.Data
@@ -54,14 +53,7 @@ annotateExportSpec globalTable exportSpec =
   EAbs l ns qn ->
     case Global.lookupType qn globalTable of
       [] -> scopeError (ENotInScope qn) exportSpec
-      [symbol@(PatSyn _ n)] ->
-        let
-          s = symbol : (filter ((== Just n) . symbolParent) $ Global.lookupValue qn globalTable)
-        in
-          EAbs (Scoped (Export s) l)
-            (noScope ns)
-            (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
-      [symbol@(PatSyn m n)] -> case Global.lookupValue qn globalTable of
+      [symbol@(PatSyn _ _)] -> case Global.lookupValue qn globalTable of
                 [] -> scopeError (ENotInScope qn) exportSpec
                 [patCtor] -> EAbs (Scoped (Export [symbol, patCtor]) l)
                           (noScope ns)

--- a/src/Language/Haskell/Names/Exports.hs
+++ b/src/Language/Haskell/Names/Exports.hs
@@ -10,7 +10,7 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.Writer
 import Data.Data
-import Language.Haskell.Exts
+import Language.Haskell.Exts hiding (PatSyn)
 import Language.Haskell.Names.Types
 import Language.Haskell.Names.ScopeUtils
 import Language.Haskell.Names.SyntaxUtils
@@ -54,6 +54,19 @@ annotateExportSpec globalTable exportSpec =
   EAbs l ns qn ->
     case Global.lookupType qn globalTable of
       [] -> scopeError (ENotInScope qn) exportSpec
+      [symbol@(PatSyn _ n)] ->
+        let
+          s = symbol : (filter ((== Just n) . symbolParent) $ Global.lookupValue qn globalTable)
+        in
+          EAbs (Scoped (Export s) l)
+            (noScope ns)
+            (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
+      [symbol@(PatSyn m n)] -> case Global.lookupValue qn globalTable of
+                [] -> scopeError (ENotInScope qn) exportSpec
+                [patCtor] -> EAbs (Scoped (Export [symbol, patCtor]) l)
+                          (noScope ns)
+                          (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
+                symbols -> scopeError (EAmbiguous qn symbols) exportSpec
       [symbol] -> EAbs (Scoped (Export [symbol]) l)
             (noScope ns)
             (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)

--- a/src/Language/Haskell/Names/Exports.hs
+++ b/src/Language/Haskell/Names/Exports.hs
@@ -6,6 +6,7 @@ module Language.Haskell.Names.Exports
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Control.Applicative
 import Control.Monad
 import Control.Monad.Writer
 import Data.Data

--- a/src/Language/Haskell/Names/GetBound.hs
+++ b/src/Language/Haskell/Names/GetBound.hs
@@ -56,6 +56,14 @@ instance (Data l) => GetBound (Decl l) l where
       FunBind _ (Match _ n _ _ _ : _) -> [n]
       FunBind _ (InfixMatch _ _ n _ _ _ : _) -> [n]
       PatBind _ p _ _ -> getBound ctx p
+      PatSyn _ p _ _ -> case p of
+        PInfixApp _ _ qn _ -> [qNameToName qn]
+        PApp _ qn _ -> [qNameToName qn]
+        PRec _ qn fs -> qNameToName qn : concatMap getFieldBound fs where
+          getFieldBound (PFieldPat _ qn' _) = [qNameToName qn']
+          getFieldBound (PFieldPun _ qn') = [qNameToName qn']
+          _ = []
+        _ -> []
       ForImp _ _ _ _ n _ -> [n]
       ForExp _ _ _ n _ -> [n]
       RulePragmaDecl{} -> []

--- a/src/Language/Haskell/Names/GlobalSymbolTable.hs
+++ b/src/Language/Haskell/Names/GlobalSymbolTable.hs
@@ -2,7 +2,7 @@
 -- | This module is designed to be imported qualified.
 module Language.Haskell.Names.GlobalSymbolTable where
 
-import Language.Haskell.Exts hiding (NewType)
+import Language.Haskell.Exts hiding (NewType, PatSyn)
 
 import Data.Map (
     Map)
@@ -55,6 +55,7 @@ isType symbol = case symbol of
     TypeFam {} -> True
     DataFam {} -> True
     Class   {} -> True
+    PatSyn {} -> True
     _ -> False
 
 isMethodOrAssociated :: Symbol -> Bool

--- a/src/Language/Haskell/Names/ModuleSymbols.hs
+++ b/src/Language/Haskell/Names/ModuleSymbols.hs
@@ -95,8 +95,9 @@ getTopDeclSymbols impTbl modulename d = (case d of
       patSyn <- listToMaybe [ PatSyn (dropAnn modulename) (dropAnn vn) | p' <- universe $ transform dropFields $ transform dropExp p, UnQual _ vn <- varp p' ]
       let
         patName = symbolName patSyn
-        fields = [ Selector (dropAnn modulename) (dropAnn vn) patName [patName] | p' <- universe $ transform dropExp p, UnQual _ vn <- vfield p' ]
-      return (patSyn : fields)
+        patCtor = Constructor (symbolModule patSyn) patName patName
+        fields = [ Selector (symbolModule patSyn) (dropAnn vn) patName [patName] | p' <- universe $ transform dropExp p, UnQual _ vn <- vfield p' ]
+      return (patSyn : patCtor : fields)
 
       where
         varp (PApp _ q _) = [q]

--- a/src/Language/Haskell/Names/Open/Base.hs
+++ b/src/Language/Haskell/Names/Open/Base.hs
@@ -41,6 +41,14 @@ data NameContext
       -- refers to a value bound in the same module.
   | Other
 
+-- | Pat node can work in different modes depending on where it got from
+data ResolveMode
+  = NormalMode
+  | SuppressBindings
+      -- ^ Supress bindings, force references instead (even for Name)
+  | BindQNames
+      -- ^ Bind QName's too
+
 -- | Contains information about the node's enclosing scope. Can be
 -- accessed through the lenses: 'gTable', 'lTable', 'nameCtx',
 -- 'instanceQualification', 'wcNames'.
@@ -53,13 +61,14 @@ data Scope = Scope
   , _nameCtx :: NameContext
   , _instQual :: Maybe (ModuleName ())
   , _wcNames :: WcNames
+  , _resMode :: ResolveMode
   }
 
 makeLens ''Scope
 
 -- | Create an initial scope
 initialScope :: ModuleName () -> Global.Table -> Scope
-initialScope moduleName tbl = Scope moduleName tbl Local.empty Other Nothing []
+initialScope moduleName tbl = Scope moduleName tbl Local.empty Other Nothing [] NormalMode
 
 -- | Merge local tables of two scopes. The other fields of the scopes are
 -- assumed to be the same.
@@ -159,3 +168,6 @@ exprUT = setNameCtx ReferenceUT
 
 instQ :: Maybe (ModuleName ()) -> Scope -> Scope
 instQ m = setL instQual m
+
+setMode :: ResolveMode -> Scope -> Scope
+setMode = setL resMode

--- a/src/Language/Haskell/Names/Types.hs
+++ b/src/Language/Haskell/Names/Types.hs
@@ -70,6 +70,11 @@ data Symbol
       , symbolName :: Name ()
       }
       -- ^ type class
+    | PatSyn
+      { symbolModule :: ModuleName ()
+      , symbolName :: Name ()
+      }
+      -- ^ pattern synonym
     deriving (Eq, Ord, Show, Data, Typeable)
 
 -- | A map from module name to list of symbols it exports.

--- a/tests/annotations/PatternSynonyms.hs
+++ b/tests/annotations/PatternSynonyms.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module PatternSynonyms where
+
+pattern SimplePat x y = [(Just [x], Right y)]
+
+pattern RecordPat { patLeft, patRight } = Just (patLeft, patRight)

--- a/tests/annotations/PatternSynonyms.hs.golden
+++ b/tests/annotations/PatternSynonyms.hs.golden
@@ -1,0 +1,21 @@
+PatternSynonyms at 1:14 is none
+SimplePat at  5:9 is a value bound here
+SimplePat at  5:9 is a value bound here
+x        at 5:19 is a value bound here
+y        at 5:21 is a value bound here
+Just     at 5:27 is not in scope
+Just     at 5:27 is not in scope
+x        at 5:33 is a local value defined at 5:19
+Right    at 5:37 is not in scope
+Right    at 5:37 is not in scope
+y        at 5:43 is a local value defined at 5:21
+RecordPat at  7:9 is a value bound here
+RecordPat at  7:9 is a value bound here
+patLeft  at 7:21 is a value bound here
+patLeft  at 7:21 is a value bound here
+patRight at 7:30 is a value bound here
+patRight at 7:30 is a value bound here
+Just     at 7:43 is not in scope
+Just     at 7:43 is not in scope
+patLeft  at 7:49 is a local value defined at 7:21
+patRight at 7:58 is a local value defined at 7:30

--- a/tests/exports/ExportListMembers.hs
+++ b/tests/exports/ExportListMembers.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 module ExportListMembers (Foo(Foo1, Foo3, c), Bar(x), N(N)) where
 
 data Foo = Foo1 | Foo2 { c :: Bool } | Foo3 { d :: Bool }

--- a/tests/exports/Prelude.hs
+++ b/tests/exports/Prelude.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 module Prelude where
 
 data DataType = Constructor1 | Constructor2

--- a/tests/run.hs
+++ b/tests/run.hs
@@ -22,7 +22,7 @@ import Text.Show.Pretty (ppShow)
 import Text.Printf
 import qualified Data.Foldable as F
 
-import Language.Haskell.Exts hiding (DataOrNew(NewType))
+import Language.Haskell.Exts hiding (DataOrNew(NewType), PatSyn)
 import qualified Language.Haskell.Exts.Syntax as Syntax (DataOrNew(NewType))
 import qualified Language.Haskell.Exts as U (ModuleName(ModuleName))
 import Language.Haskell.Names

--- a/tests/run.hs
+++ b/tests/run.hs
@@ -167,6 +167,7 @@ formatSymbol NewType {} = "newtype"
 formatSymbol TypeFam {} = "type family"
 formatSymbol DataFam {} = "data family"
 formatSymbol Class {} = "type class"
+formatSymbol PatSyn {} = "pattern synonym"
 
 formatInfo :: NameInfo SrcSpan -> String
 formatInfo (LocalValue loc) =


### PR DESCRIPTION
Pattern synonyms were ignored.
Now there is new `PatSyn` value in `Symbol`. Fields exported as selectors.