### PR TITLE
Pattern synonyms again.

### DIFF
--- a/src/Language/Haskell/Names/Exports.hs
+++ b/src/Language/Haskell/Names/Exports.hs
@@ -10,7 +10,7 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.Writer
 import Data.Data
-import Language.Haskell.Exts hiding (PatSyn)
+import Language.Haskell.Exts
 import Language.Haskell.Names.Types
 import Language.Haskell.Names.ScopeUtils
 import Language.Haskell.Names.SyntaxUtils
@@ -51,15 +51,16 @@ annotateExportSpec globalTable exportSpec =
       [symbol] -> EVar (Scoped (Export [symbol]) l)
             (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
       symbols -> scopeError (EAmbiguous qn symbols) exportSpec
+  EAbs l ns@(PatternNamespace _) qn ->
+    case Global.lookupValue qn globalTable of
+      [] -> scopeError (ENotInScope qn) exportSpec
+      [symbol] -> EAbs (Scoped (Export [symbol]) l)
+            (noScope ns)
+            (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
+      symbols -> scopeError (EAmbiguous qn symbols) exportSpec
   EAbs l ns qn ->
     case Global.lookupType qn globalTable of
       [] -> scopeError (ENotInScope qn) exportSpec
-      [symbol@(PatSyn _ _)] -> case Global.lookupValue qn globalTable of
-                [] -> scopeError (ENotInScope qn) exportSpec
-                [patCtor] -> EAbs (Scoped (Export [symbol, patCtor]) l)
-                          (noScope ns)
-                          (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)
-                symbols -> scopeError (EAmbiguous qn symbols) exportSpec
       [symbol] -> EAbs (Scoped (Export [symbol]) l)
             (noScope ns)
             (Scoped (GlobalSymbol symbol (dropAnn qn)) <$> qn)

--- a/src/Language/Haskell/Names/GlobalSymbolTable.hs
+++ b/src/Language/Haskell/Names/GlobalSymbolTable.hs
@@ -45,6 +45,8 @@ isValue symbol = case symbol of
     Method {} -> True
     Selector {} -> True
     Constructor {} -> True
+    PatternConstructor {} -> True
+    PatternSelector {} -> True
     _ -> False
 
 isType :: Symbol -> Bool
@@ -55,7 +57,6 @@ isType symbol = case symbol of
     TypeFam {} -> True
     DataFam {} -> True
     Class   {} -> True
-    PatSyn {} -> True
     _ -> False
 
 isMethodOrAssociated :: Symbol -> Bool

--- a/src/Language/Haskell/Names/Open/Instances.hs
+++ b/src/Language/Haskell/Names/Open/Instances.hs
@@ -10,7 +10,7 @@
 
 module Language.Haskell.Names.Open.Instances where
 
-import Language.Haskell.Names.Types hiding (PatSyn)
+import Language.Haskell.Names.Types
 import Language.Haskell.Names.Open.Base
 import Language.Haskell.Names.Open.Derived ()
 import Language.Haskell.Names.GetBound
@@ -19,14 +19,12 @@ import Language.Haskell.Exts
 import Language.Haskell.Names.SyntaxUtils
 import qualified Data.Data as D
 import Control.Applicative
-import Data.Generics.Traversable
 import Data.Typeable
 import Data.Type.Equality
 import Data.Lens.Light
 import Data.List
 import qualified Data.Traversable as T
 
-import Debug.Trace
 
 c :: Applicative w => c -> w c
 c = pure
@@ -90,37 +88,7 @@ instance (Resolvable l, SrcInfo l, D.Data l) => Resolvable (Decl l) where
           <| sc'       -: rule
           <| sc'       -: mInstDecls
       _ -> defaultRtraverse e sc
-    where
-      patSyn pat sc = case pat of
-        PInfixApp l pat1 name pat2 ->
-          c PInfixApp
-            <| sc             -: l
-            <| sc             -: pat1
-            <*> qname name sc
-            <| sc             -: pat2
-        PApp l name pat ->
-          c PApp
-            <| sc           -: l
-            <*> qname name sc
-            <| sc           -: pat
-        PRec l name pfs ->
-          c PRec
-            <| sc           -: l
-            <*> qname name sc
-            <*> T.for pfs (`patSynField` sc)
-        _ -> defaultRtraverse pat sc
-      patSynField fs sc = case fs of
-        PFieldPat l name pat ->
-          c PFieldPat
-            <| sc         -: l
-            <*> qname name sc
-            <| sc         -: pat
-        PFieldPun l name ->
-          c PFieldPun
-            <| sc         -: l
-            <*> qname name sc
-        PFieldWildcard {} -> defaultRtraverse fs sc
-      qname name sc = fmap nameToQName (alg (qNameToName name) (binderV sc))
+
 
 instanceRuleClass :: InstRule l -> QName l
 instanceRuleClass (IParen _ instRule) = instanceRuleClass instRule

--- a/src/Language/Haskell/Names/ScopeUtils.hs
+++ b/src/Language/Haskell/Names/ScopeUtils.hs
@@ -25,6 +25,8 @@ symbolParent (Constructor { typeName = n }) = Just n
 symbolParent (Method { className = n }) = Just n
 symbolParent (TypeFam { associate = as }) = as
 symbolParent (DataFam { associate = as }) = as
+symbolParent (PatternConstructor { patternTypeName = mn}) = mn
+symbolParent (PatternSelector { patternTypeName = mn}) = mn
 symbolParent _ = Nothing
 
 computeSymbolTable

--- a/src/Language/Haskell/Names/Types.hs
+++ b/src/Language/Haskell/Names/Types.hs
@@ -70,11 +70,19 @@ data Symbol
       , symbolName :: Name ()
       }
       -- ^ type class
-    | PatSyn
+    | PatternConstructor
       { symbolModule :: ModuleName ()
       , symbolName :: Name ()
+      , patternTypeName :: Maybe (Name ())
       }
-      -- ^ pattern synonym
+      -- ^ pattern synonym constructor
+    | PatternSelector
+      { symbolModule :: ModuleName ()
+      , symbolName :: Name ()
+      , patternTypeName :: Maybe (Name ())
+      , patternConstructorName :: Name ()
+      }
+      -- ^ pattern synonym selector
     deriving (Eq, Ord, Show, Data, Typeable)
 
 -- | A map from module name to list of symbols it exports.

--- a/tests/annotations/PatternSynonyms.hs
+++ b/tests/annotations/PatternSynonyms.hs
@@ -1,7 +1,42 @@
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PatternSynonyms, NamedFieldPuns #-}
 
 module PatternSynonyms where
 
-pattern SimplePat x y = [(Just [x], Right y)]
 
-pattern RecordPat { patLeft, patRight } = Just (patLeft, patRight)
+data Type = App String [Type]
+
+pattern Arrow t1 t2 = App "->" [t1, t2]
+pattern Int = App "Int" []
+pattern Maybe t = App "Maybe" [t]
+
+collectArgs :: Type -> [Type]
+collectArgs (Arrow t1 t2) = t1 : collectArgs t2
+collectArgs _             = []
+
+isInt :: Type -> Bool
+isInt Int = True
+isInt _   = False
+
+isIntEndo :: Type -> Bool
+isIntEndo (Arrow Int Int) = True
+isIntEndo _               = False
+
+intEndo :: Type
+intEndo = Arrow Int Int
+
+pattern Head x <- x:xs
+
+pattern HeadC x <- x:xs where
+  HeadC x = [x]
+
+pattern Point :: Int -> Int -> (Int, Int)
+pattern Point{x, y} = (x, y)
+
+zero = Point 0 0
+zero' = Point { x = 0, y = 0}
+isZero (Point 0 0) = True
+isZero' (Point { x = 0, y = 0 }) = True
+getX (Point {x}) = x
+setX = (0, 0) { x = 1 } == (1,0)
+getX' = x (0,0) == 0
+

--- a/tests/annotations/PatternSynonyms.hs.golden
+++ b/tests/annotations/PatternSynonyms.hs.golden
@@ -1,21 +1,159 @@
 PatternSynonyms at 1:14 is none
-SimplePat at  5:9 is a value bound here
-SimplePat at  5:9 is a value bound here
-x        at 5:19 is a value bound here
-y        at 5:21 is a value bound here
-Just     at 5:27 is not in scope
-Just     at 5:27 is not in scope
-x        at 5:33 is a local value defined at 5:19
-Right    at 5:37 is not in scope
-Right    at 5:37 is not in scope
-y        at 5:43 is a local value defined at 5:21
-RecordPat at  7:9 is a value bound here
-RecordPat at  7:9 is a value bound here
-patLeft  at 7:21 is a value bound here
-patLeft  at 7:21 is a value bound here
-patRight at 7:30 is a value bound here
-patRight at 7:30 is a value bound here
-Just     at 7:43 is not in scope
-Just     at 7:43 is not in scope
-patLeft  at 7:49 is a local value defined at 7:21
-patRight at 7:58 is a local value defined at 7:30
+NamedFieldPuns at 1:31 is none
+Type     at  6:6 is a type or class defined here
+App      at 6:13 is a value bound here
+String   at 6:17 is not in scope
+String   at 6:17 is not in scope
+Type     at 6:25 is a global data type, PatternSynonyms.Type
+Type     at 6:25 is a global data type, PatternSynonyms.Type
+Arrow    at  8:9 is a value bound here
+Arrow    at  8:9 is a value bound here
+t1       at 8:15 is a value bound here
+t2       at 8:18 is a value bound here
+App      at 8:23 is a global constructor, PatternSynonyms.App
+App      at 8:23 is a global constructor, PatternSynonyms.App
+t1       at 8:33 is a local value defined at 8:15
+t2       at 8:37 is a local value defined at 8:18
+Int      at  9:9 is a value bound here
+Int      at  9:9 is a value bound here
+App      at 9:15 is a global constructor, PatternSynonyms.App
+App      at 9:15 is a global constructor, PatternSynonyms.App
+Maybe    at 10:9 is a value bound here
+Maybe    at 10:9 is a value bound here
+t        at 10:15 is a value bound here
+App      at 10:19 is a global constructor, PatternSynonyms.App
+App      at 10:19 is a global constructor, PatternSynonyms.App
+t        at 10:32 is a local value defined at 10:15
+collectArgs at 12:1 is a global value, PatternSynonyms.collectArgs
+Type     at 12:16 is a global data type, PatternSynonyms.Type
+Type     at 12:16 is a global data type, PatternSynonyms.Type
+Type     at 12:25 is a global data type, PatternSynonyms.Type
+Type     at 12:25 is a global data type, PatternSynonyms.Type
+collectArgs at 13:1 is a value bound here
+Arrow    at 13:14 is a global pattern constructor, PatternSynonyms.Arrow
+Arrow    at 13:14 is a global pattern constructor, PatternSynonyms.Arrow
+t1       at 13:20 is a value bound here
+t2       at 13:23 is a value bound here
+t1       at 13:29 is a local value defined at 13:20
+t1       at 13:29 is a local value defined at 13:20
+:        at 13:32 is none
+collectArgs at 13:34 is a global value, PatternSynonyms.collectArgs
+collectArgs at 13:34 is a global value, PatternSynonyms.collectArgs
+t2       at 13:46 is a local value defined at 13:23
+t2       at 13:46 is a local value defined at 13:23
+collectArgs at 14:1 is a value bound here
+isInt    at 16:1 is a global value, PatternSynonyms.isInt
+Type     at 16:10 is a global data type, PatternSynonyms.Type
+Type     at 16:10 is a global data type, PatternSynonyms.Type
+Bool     at 16:18 is not in scope
+Bool     at 16:18 is not in scope
+isInt    at 17:1 is a value bound here
+Int      at 17:7 is a global pattern constructor, PatternSynonyms.Int
+Int      at 17:7 is a global pattern constructor, PatternSynonyms.Int
+True     at 17:13 is not in scope
+True     at 17:13 is not in scope
+isInt    at 18:1 is a value bound here
+False    at 18:13 is not in scope
+False    at 18:13 is not in scope
+isIntEndo at 20:1 is a global value, PatternSynonyms.isIntEndo
+Type     at 20:14 is a global data type, PatternSynonyms.Type
+Type     at 20:14 is a global data type, PatternSynonyms.Type
+Bool     at 20:22 is not in scope
+Bool     at 20:22 is not in scope
+isIntEndo at 21:1 is a value bound here
+Arrow    at 21:12 is a global pattern constructor, PatternSynonyms.Arrow
+Arrow    at 21:12 is a global pattern constructor, PatternSynonyms.Arrow
+Int      at 21:18 is a global pattern constructor, PatternSynonyms.Int
+Int      at 21:18 is a global pattern constructor, PatternSynonyms.Int
+Int      at 21:22 is a global pattern constructor, PatternSynonyms.Int
+Int      at 21:22 is a global pattern constructor, PatternSynonyms.Int
+True     at 21:29 is not in scope
+True     at 21:29 is not in scope
+isIntEndo at 22:1 is a value bound here
+False    at 22:29 is not in scope
+False    at 22:29 is not in scope
+intEndo  at 24:1 is a global value, PatternSynonyms.intEndo
+Type     at 24:12 is a global data type, PatternSynonyms.Type
+Type     at 24:12 is a global data type, PatternSynonyms.Type
+intEndo  at 25:1 is a value bound here
+Arrow    at 25:11 is a global pattern constructor, PatternSynonyms.Arrow
+Arrow    at 25:11 is a global pattern constructor, PatternSynonyms.Arrow
+Int      at 25:17 is a global pattern constructor, PatternSynonyms.Int
+Int      at 25:17 is a global pattern constructor, PatternSynonyms.Int
+Int      at 25:21 is a global pattern constructor, PatternSynonyms.Int
+Int      at 25:21 is a global pattern constructor, PatternSynonyms.Int
+Head     at 27:9 is a value bound here
+Head     at 27:9 is a value bound here
+x        at 27:14 is a value bound here
+x        at 27:19 is a local value defined at 27:14
+:        at 27:20 is none
+xs       at 27:21 is not in scope
+HeadC    at 29:9 is a value bound here
+HeadC    at 29:9 is a value bound here
+x        at 29:15 is a value bound here
+x        at 29:20 is a local value defined at 29:15
+:        at 29:21 is none
+xs       at 29:22 is not in scope
+HeadC    at 30:3 is a global pattern constructor, PatternSynonyms.HeadC
+HeadC    at 30:3 is a global pattern constructor, PatternSynonyms.HeadC
+x        at 30:9 is a value bound here
+x        at 30:14 is a global pattern selector, PatternSynonyms.x
+x        at 30:14 is a global pattern selector, PatternSynonyms.x
+Point    at 32:9 is none
+Int      at 32:18 is not in scope
+Int      at 32:18 is not in scope
+Int      at 32:25 is not in scope
+Int      at 32:25 is not in scope
+Int      at 32:33 is not in scope
+Int      at 32:33 is not in scope
+Int      at 32:38 is not in scope
+Int      at 32:38 is not in scope
+Point    at 33:9 is a value bound here
+Point    at 33:9 is a value bound here
+x        at 33:15 is a value bound here
+x        at 33:15 is a value bound here
+y        at 33:18 is a value bound here
+y        at 33:18 is a value bound here
+x        at 33:24 is a local value defined at 33:15
+y        at 33:27 is a local value defined at 33:18
+zero     at 35:1 is a value bound here
+Point    at 35:8 is a global pattern constructor, PatternSynonyms.Point
+Point    at 35:8 is a global pattern constructor, PatternSynonyms.Point
+zero'    at 36:1 is a value bound here
+Point    at 36:9 is a global pattern constructor, PatternSynonyms.Point
+Point    at 36:9 is a global pattern constructor, PatternSynonyms.Point
+x        at 36:17 is a global pattern selector, PatternSynonyms.x
+x        at 36:17 is a global pattern selector, PatternSynonyms.x
+y        at 36:24 is a global pattern selector, PatternSynonyms.y
+y        at 36:24 is a global pattern selector, PatternSynonyms.y
+isZero   at 37:1 is a value bound here
+Point    at 37:9 is a global pattern constructor, PatternSynonyms.Point
+Point    at 37:9 is a global pattern constructor, PatternSynonyms.Point
+True     at 37:22 is not in scope
+True     at 37:22 is not in scope
+isZero'  at 38:1 is a value bound here
+Point    at 38:10 is a global pattern constructor, PatternSynonyms.Point
+Point    at 38:10 is a global pattern constructor, PatternSynonyms.Point
+x        at 38:18 is a global pattern selector, PatternSynonyms.x
+x        at 38:18 is a global pattern selector, PatternSynonyms.x
+y        at 38:25 is a global pattern selector, PatternSynonyms.y
+y        at 38:25 is a global pattern selector, PatternSynonyms.y
+True     at 38:36 is not in scope
+True     at 38:36 is not in scope
+getX     at 39:1 is a value bound here
+Point    at 39:7 is a global pattern constructor, PatternSynonyms.Point
+Point    at 39:7 is a global pattern constructor, PatternSynonyms.Point
+x        at 39:14 is a global pattern selector, PatternSynonyms.x
+x        at 39:14 is a global pattern selector, PatternSynonyms.x
+x        at 39:20 is a local value defined at 39:14
+x        at 39:20 is a local value defined at 39:14
+setX     at 40:1 is a value bound here
+x        at 40:17 is a global pattern selector, PatternSynonyms.x
+x        at 40:17 is a global pattern selector, PatternSynonyms.x
+==       at 40:25 is not in scope
+==       at 40:25 is not in scope
+getX'    at 41:1 is a value bound here
+x        at 41:9 is a global pattern selector, PatternSynonyms.x
+x        at 41:9 is a global pattern selector, PatternSynonyms.x
+==       at 41:17 is not in scope
+==       at 41:17 is not in scope

--- a/tests/run.hs
+++ b/tests/run.hs
@@ -167,7 +167,8 @@ formatSymbol NewType {} = "newtype"
 formatSymbol TypeFam {} = "type family"
 formatSymbol DataFam {} = "data family"
 formatSymbol Class {} = "type class"
-formatSymbol PatSyn {} = "pattern synonym"
+formatSymbol PatternConstructor {} = "pattern constructor"
+formatSymbol PatternSelector {} = "pattern selector"
 
 formatInfo :: NameInfo SrcSpan -> String
 formatInfo (LocalValue loc) =


### PR DESCRIPTION
@mvoidex This pull request changes how we treat pattern synonyms. It would be great if you could review it and tell me if I missed something. Instead of a type-level pattern synonym we have value-level pattern constructors and pattern selectors. I've looked at the description of pattern synonyms in the [GHC documentation](http://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#pattern-synonyms) and in the [GHC wiki](https://ghc.haskell.org/trac/ghc/wiki/PatternSynonyms/AssociatingSynonyms) and I don't think pattern synonym declarations introduce type-level entities. What do you think?
