### PR TITLE
Bump aeson upper bound to include 1.1.*

### DIFF
--- a/haskell-names.cabal
+++ b/haskell-names.cabal
@@ -242,7 +242,7 @@ Library
     , filepath >= 1.1 && < 1.5
     , containers >= 0.2 && < 0.6
     , uniplate >= 1.5.1 && < 1.7
-    , aeson >= 0.8.0.2 && < 1.1
+    , aeson >= 0.8.0.2 && < 1.2
     , bytestring >= 0.10.4.0 && < 0.11
     , data-lens-light >= 0.1.2.1 && < 0.2
               , traverse-with-class >= 0.2.0.3 && < 0.3


### PR DESCRIPTION
Tests passed without any other changes.

Should resolve: https://github.com/fpco/stackage/issues/2177