### PR TITLE
Bump upper bound on `haskell-src-exts`

### DIFF
--- a/haskell-names.cabal
+++ b/haskell-names.cabal
@@ -236,7 +236,7 @@ Library
   Default-Language: Haskell2010
   Build-depends:
       base >= 4 && < 5
-    , haskell-src-exts >= 1.21 && < 1.23
+    , haskell-src-exts >= 1.21 && < 1.24
     , mtl >= 2.2.1 && < 2.3
     , transformers >=0.4.2.0 && < 0.6
     , filepath >= 1.1 && < 1.5


### PR DESCRIPTION
This unblocks [Stackage on `haskell-src-exts-1.23.0`](https://github.com/commercialhaskell/stackage/issues/5048). 

The [`haskell-src-exts` changelog](https://hackage.haskell.org/package/haskell-src-exts-1.23.0/changelog) indicates that this is only adding new constructors to sum types. Neither appear to be reexported in the library, so this should be safe as a minor version bump.

Building locally doesn't show any warnings that should be introduced by this.